### PR TITLE
fix: issue with HTTP-409 due to the version suffix removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply from: rootProject.file('gradle/install-git-hooks.gradle')
 
 allprojects {
     group = project.group
-    version = project.version
+    version = project.version + "-" + getCheckedOutGitCommitHash()
 }
 
 repositories {


### PR DESCRIPTION
[This](https://github.com/EFA-FHB/eforms-validator-core/commit/13c0b7df4a1155307a1197ce2bee268e25fc8070) commit has removed the version suffix causing the issues with HTTP-409 for the package duplicates. The PR tries to re-add the suffix with the git short-SHA 