### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development') }}
     needs: [test]
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      packages: write
 
     name: "🚀 publish"
 
@@ -118,5 +122,4 @@ jobs:
         with:
           arguments: publish
         env:
-          GITHUB_TOKEN: ${{ secrets.JAVA_TOKEN }}
-          GITHUB_ACTOR: ${{ secrets.JAVA_ACTOR }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using GITHUB_TOKEN to publish packages instead of JAVA_ACTOR and JAVA_TOKEN